### PR TITLE
Add nullable to image field in articles

### DIFF
--- a/database/migrations/2021_08_13_173429_create_article_table.php
+++ b/database/migrations/2021_08_13_173429_create_article_table.php
@@ -18,7 +18,7 @@ class CreateArticleTable extends Migration
             $table->string('name');
             $table->string('description',1000);
             $table->string('author');
-            $table->string('image');
+            $table->string('image')->nullable();
             $table->timestamp('public_at')->nullable();
             $table->unsignedBigInteger('category_id')->nullable();
             $table->foreign('category_id')->references('id')->on('categories')->onDelete('cascade')->onUpdate('cascade');


### PR DESCRIPTION
Add optional field to image in article because when you run a seeder it breaks due to the factory generates only items with name, description and author, and as image was required, the migration breaks